### PR TITLE
Add support for ChaCha20-Poly1305 AEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,21 @@ See [here][GitHub releases] for earlier releases.
 
 Note that Tempel is [not intended](../../wiki/3-Faq#can-i-decrypt-tempel-data-with-other-tools) for interop with other cryptographic tools/APIs.
 
+## Roadmap
+
+Tempel has a fixed scope, and is **fully complete**. I'm happy with its design and implementation, and believe it meets all its objectives in its current form. I'm not anticipating significant changes.
+
+Still, given the sensitivity of the problem domain, I plan to approach Tempel's official stable release as a phased rollout to allow time for user feedback before locking things down:
+
+| Phase | Date    | Release       | Appropriate for
+| :-:   | :--     | :--           | :--
+|  ➤    | 2023-11 | `v1.0-alpha`  | Dev/testing with disposable data
+|       | 2024-01 | `v1.0-beta`   | Dev/testing with disposable data
+|       | 2024-03 | `v1.0-RC`     | Staging, with ephemeral or low-value data
+|       | 2024-05 | `v1.0` final  | Production, with real data
+
+`v1.0` final will be considered "**done**"- the library is expected to need+see only minimal maintance from that point.
+
 ## Disclaimer
 
 **Important**: while Tempel has been written and tested with care, the nature of the problem domain inevitably means that bugs and/or misuse can be **especially harmful and/or easy to make**.

--- a/README.md
+++ b/README.md
@@ -23,10 +23,11 @@ See [here][GitHub releases] for earlier releases.
 - **Easy-to-use, high-level API** focused on [common tasks](../../wiki/2-Examples) like logins, encryption, signing, etc.
 - **Reasonable defaults** including choice of algorithms and work factors
 - **Future-proof data formats** with auto-updated algorithms and work factors over time
-- Support for [⧉ symmetric](https://en.wikipedia.org/wiki/Symmetric-key_algorithm) and [⧉ asymmetric](https://en.wikipedia.org/wiki/Public-key_cryptography) (public-key) encryption
+- Support for [⧉ symmetric](https://en.wikipedia.org/wiki/Symmetric-key_algorithm), [⧉ asymmetric](https://en.wikipedia.org/wiki/Public-key_cryptography) (public-key), and [⧉ end-to-end](https://en.wikipedia.org/wiki/End-to-end_encryption) (E2EE) encryption
 - Automatic [⧉ scrypt](https://en.wikipedia.org/wiki/Scrypt) and [⧉ pbkdf2](https://en.wikipedia.org/wiki/PBKDF2) support for easy **password-based key stretching**
 - Simple **key management API** for password resets, key rotations, etc.
-- Beginner-oriented docstrings and [documentation](#documentation)
+- Beginner-oriented [documentation](#documentation) and docstrings
+- **Comprehensive test suite** with >60k unit tests
 
 Note that Tempel is [not intended](../../wiki/3-Faq#can-i-decrypt-tempel-data-with-other-tools) for interop with other cryptographic tools/APIs.
 
@@ -38,18 +39,14 @@ Bugs and/or misuse could lead to [security vulnerabilities](../../wiki/3-FAQ#how
 
 Please be **very careful** evaluating Tempel and/or other cryptographic libraries/frameworks before use, especially new libraries/frameworks like Tempel!
 
+## Security
+
+See [here](../../security) for **security advisories** and/or to **report security vulnerabilities**.
+
 ## Documentation
 
 - [Full documentation][GitHub wiki] (**getting started** and more)
 - Auto-generated API reference: [Codox][Codox docs], [clj-doc][clj-doc docs]
-
-## Security advisories
-
-No advisories as of last README update. If any security vulnerabilities are discovered, they will be listed here along with an appropriate CVE.
-
-## Security reports
-
-To report a possible security vulnerability, **please email me** at `my first name at taoensso.com`. For particularly sensitive content, you may encrypt your message with my [public PGP/GPG key](https://www.taoensso.com/pgp). Thank you! - Peter Taoussanis
 
 ## Funding
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security Policy
+
+## Security Advisories
+
+All security advisories will be posted [on GitHub](https://github.com/taoensso/tempel/security/advisories).
+
+## Reporting a Vulnerability
+
+Please report possible security vulnerabilities [via GitHub](https://github.com/taoensso/tempel/security/advisories), or by emailing me at `my first name at taoensso.com`. You may encrypt emails with [my public PGP/GPG key](https://www.taoensso.com/pgp).
+
+Thank you!
+\- [Peter Taoussanis](https://www.taoensso.com)

--- a/src/taoensso/tempel.clj
+++ b/src/taoensso/tempel.clj
@@ -463,7 +463,7 @@
   (case return-kind
     :ba-content ?ba-cnt
     :ba-aad     ?ba-aad
-    :as-map
+    :map
     (enc/assoc-some {}
       :ba-content ?ba-cnt
       :ba-aad     ?ba-aad)
@@ -474,7 +474,7 @@
       :cnt (bytes/?utf8-ba->?str ?ba-cnt))
 
     (enc/unexpected-arg! return-kind
-      {:expected #{:ba-content :ba-aad :as-map}
+      {:expected #{:ba-content :ba-aad :map}
        :context  context})))
 
 (defn encrypt-with-password
@@ -563,7 +563,7 @@
   Return value depends on `:return` option:
     `:ba-content` - Returns decrypted byte[] content (default)
     `:ba-aad`     - Returns verified unencrypted embedded ?byte[] AAD
-    `:as-map`     - Returns {:keys [ba-aad ba-content]} map
+    `:map`        - Returns {:keys [ba-aad ba-content]} map
 
   Takes a password (string, byte[], or char[]). Password will be \"stretched\"
   using an appropriate \"Password-Based Key Derivation Function\" (PBKDF).
@@ -711,7 +711,7 @@
   Return value depends on `:return` option:
     `:ba-content` - Returns decrypted byte[] content (default)
     `:ba-aad`     - Returns verified unencrypted embedded ?byte[] AAD
-    `:as-map`     - Returns {:keys [ba-aad ba-content]} map
+    `:map`        - Returns {:keys [ba-aad ba-content]} map
 
   Takes a `KeyChain` (see `keychain`) or byte[] key.
   Will throw on decryption failure (bad key, etc.)."
@@ -919,7 +919,7 @@
   Return value depends on `:return` option:
     `:ba-content` - Returns decrypted byte[] content (default)
     `:ba-aad`     - Returns verified unencrypted embedded ?byte[] AAD
-    `:as-map`     - Returns {:keys [ba-aad ba-content]} map
+    `:map`        - Returns {:keys [ba-aad ba-content]} map
 
   Takes a `KeyChain` (see `keychain`) or `KeyPair` (see `keypair-create`).
   Key algorithm must support use as an asymmetric cipher.
@@ -1141,7 +1141,7 @@
   Return value depends on `:return` option:
     `:ba-content` - Returns decrypted byte[] content (default)
     `:ba-aad`     - Returns verified unencrypted embedded ?byte[] AAD
-    `:as-map`     - Returns {:keys [ba-aad ba-content]} map
+    `:map`        - Returns {:keys [ba-aad ba-content]} map
 
   Takes `KeyChain`s (see `keychain`) and/or `KeyPair`s (see `keypair-create`).
   Key algorithm must support key agreement.
@@ -1318,7 +1318,7 @@
   Return value depends on `:return` option:
     `:ba-content` - Returns verified ?byte[] content (when embedded)
     `:ba-aad`     - Returns verified ?byte[] AAD     (when embedded)
-    `:as-map`     - Returns {:keys [ba-aad ba-content]} map (default)
+    `:map`        - Returns {:keys [ba-aad ba-content]} map (default)
 
   Returns nil when verification fails.
 
@@ -1333,10 +1333,10 @@
   {:arglists
    '([ba-signed signer-key-pub &
       [{:keys [ba-content return ba-akm]
-        :or   {return :as-map}}]])}
+        :or   {return :map}}]])}
 
   [ba-signed signer-key-pub & [opts]]
-  (let [{:keys [ba-content return] :or {return :as-map}} opts
+  (let [{:keys [ba-content return] :or {return :map}} opts
         {:keys [ba-akm] :as opts+}
         (get-opts+ opts)]
 
@@ -1372,4 +1372,4 @@
 (comment
   (let [kc        (keychain)
         ba-signed (sign (as-ba "cnt") kc {:ba-aad (as-ba "aad")})]
-    (signed ba-signed kc {:return :as-map #_:_test})))
+    (signed ba-signed kc {:return :map #_:_test})))

--- a/src/taoensso/tempel.clj
+++ b/src/taoensso/tempel.clj
@@ -10,8 +10,8 @@
   Abbreviations:
     External:
       pbkdf - Password Based Key Derivation Function
-      aad   - Additional Associated Aata (see also `aad-help`)
-      akm   - Additional Keying Material (see also `akm-help`)
+      aad   - Additional Associated Aata (see `aad-help`)
+      akm   - Additional Keying Material (see `akm-help`)
       kek   - Key encryption key (key used to encrypt another key)
       cnt   - Unencrypted content
       ecnt  - Encrypted   content
@@ -205,14 +205,14 @@
       and resources spent during normal operation.
 
       The `:ref-<num>-msecs` keywords take approximately the described amount of
-      time on a 2020 M1 Macbook Pro. See also `pbkdf-nwf-estimate` docstring.
+      time on a 2020 M1 Macbook Pro. See `pbkdf-nwf-estimate`.
 
       Default: `:ref-100-msecs`, a reasonable value for many logins.
 
     `:sym-cipher-algo` ∈ #{*:aes-gcm-128-v1 :aes-gcm-256-v1}
       The symmetric cipher algorithm to use. A cipher that supports \"AEAD\"
       (Authenticated Encryption with Associated Data) must generally be provided
-      in order to use `:ba-aad` options (see `aad-help` docstring).
+      in order to use `:ba-aad` options (see `aad-help`).
 
       Default: `:aes-gcm-128-v1`, a good general-purpose symmetric cipher with
       AEAD support.
@@ -223,7 +223,7 @@
 
     `:keypair-creator` ∈ #{<function> <delay>}
       The function to use when generating asymmetric keypairs.
-      See the `keypair-create` and `keypair-creator` docstrings for details.
+      See `keypair-create`, `keypair-creator` for details.
 
       Default: `default-keypair-creator_`, which uses up to 10% of threads
       to buffer up to 16 keypairs per type.
@@ -232,13 +232,13 @@
 
     `:symmetric-keys`
       Symmetric keys to add to new `KeyChain`s.
-      See the `keychain` docstring for details.
+      See `keychain` for details.
 
       Default: a single random symmetric key.
 
     `:asymmetric-keypairs`
       Asymmetric keypairs to add to new `KeyChain`s.
-      See the `keychain` docstring for details.
+      See `keychain` for details.
 
       Default:
         - A single new `:rsa-3072` keypair, and
@@ -336,7 +336,7 @@
   (unencrypted) data embedded in the byte[].
 
   Possible keys:
-    `:ba-aad`          - See `aad-help` docstring.
+    `:ba-aad`          - See `aad-help`
     `:keychain`        - Public-key part of encrypted `KeyChain`
     `:key-id`          - See `:embed-key-ids?` option of `encrypt-X` API
     `:receiver-key-id` - ''
@@ -481,7 +481,7 @@
   "Uses a symmetric cipher to encrypt the given byte[] content and return
   a byte[] that includes:
     - The encrypted content
-    - Optional unencrypted AAD (see `aad-help` docstring)
+    - Optional unencrypted AAD (see `aad-help`)
     - Envelope data necessary for decryption (specifies algorithms, etc.)
 
   Takes a password (string, byte[], or char[]).
@@ -491,10 +491,10 @@
   Decrypt output with: `decrypt-with-password`.
 
   Options:
-    `:ba-aad` - See `aad-help` docstring
-    `:ba-akm` - See `akm-help` dosctring
+    `:ba-aad` - See `aad-help`
+    `:ba-akm` - See `akm-help`
 
-    And see `*config*` docstring for details:
+    And see `*config*` for details:
       `hash-algo`, `sym-cipher-algo`, `pbkdf-algo`, `pbkdf-nwf`,
       `embed-key-ids?`, `embed-hmac?`, `backup-key`, `backup-opts`."
 
@@ -636,17 +636,17 @@
   "Uses a symmetric cipher to encrypt the given byte[] content and return
   a byte[] that includes:
     - The encrypted content
-    - Optional unencrypted AAD (see `aad-help` docstring)
+    - Optional unencrypted AAD (see `aad-help`)
     - Envelope data necessary for decryption (specifies algorithms, etc.)
 
   Takes a `KeyChain` (see `keychain`) or byte[] key.
   Decrypt output with: `decrypt-with-symmetric-key`.
 
   Options:
-    `:ba-aad` - See `aad-help` docstring
-    `:ba-akm` - See `akm-help` docstring
+    `:ba-aad` - See `aad-help`
+    `:ba-akm` - See `akm-help`
 
-    And see `*config*` docstring for details:
+    And see `*config*` for details:
       `hash-algo`, `sym-cipher-algo`, `embed-key-ids?`,
       `backup-key`, `backup-opts`."
 
@@ -783,7 +783,7 @@
   "Uses a symmetric or hybrid (symmetric + asymmetric) scheme to encrypt the
   given content byte[] and return a byte[] that includes:
     - The encrypted content
-    - Optional unencrypted AAD (see `aad-help` docstring)
+    - Optional unencrypted AAD (see `aad-help`)
     - Envelope data necessary for decryption (specifies algorithms, etc.)
 
   Takes a `KeyChain` (see `keychain`) or `KeyPair` (see `keypair-create`).
@@ -796,10 +796,10 @@
   Decrypt output byte[] with: `decrypt-with-1-keypair`.
 
   Options:
-    `:ba-aad` - See `aad-help` docstring
-    `:ba-akm` - See `akm-help` docstring
+    `:ba-aad` - See `aad-help`
+    `:ba-akm` - See `akm-help`
 
-    And see `*config*` docstring for details:
+    And see `*config*` for details:
       `hash-algo`, `sym-cipher-algo`, `asym-cipher-algo`,
       `embed-key-ids`, `backup-key`, `backup-opts`."
 
@@ -1043,7 +1043,7 @@
   "Uses a hybrid (symmetric + asymmetric) scheme to encrypt the given content
   byte[] and return a byte[] that includes:
     - The encrypted content
-    - Optional unencrypted AAD (see `aad-help` docstring)
+    - Optional unencrypted AAD (see `aad-help`)
     - Envelope data necessary for decryption (specifies algorithms, etc.)
 
   Takes `KeyChain`s (see `keychain`) and/or `KeyPair`s (see `keypair-create`).
@@ -1061,10 +1061,10 @@
   Decrypt output byte[] with: `decrypt-with-2-keypairs`.
 
   Options:
-    `:ba-aad` - See `aad-help` docstring
-    `:ba-akm` - See `akm-help` docstring
+    `:ba-aad` - See `aad-help`
+    `:ba-akm` - See `akm-help`
 
-    And see `*config*` docstring for details:
+    And see `*config*` for details:
       `hash-algo`, `ka-algo`, `sym-cipher-algo`,
       `embed-key-ids?`, `backup-key`, `backup-opts`."
 
@@ -1238,7 +1238,7 @@
   "Cryptographically signs the given content byte[] and returns a byte[]
   that includes:
     - Optional unencrypted content (see `embed-content?` option below)
-    - Optional unencrypted AAD     (see `aad-help` docstring)
+    - Optional unencrypted AAD     (see `aad-help`)
     - Envelope data necessary for verification (specifies algorithms, etc.)
 
   Produces:
@@ -1255,11 +1255,11 @@
   Verify with: `signed`.
 
   Options:
-    `:ba-aad`         - See `aad-help` docstring
-    `:ba-akm`         - See `akm-help` dosctring
+    `:ba-aad`         - See `aad-help`
+    `:ba-akm`         - See `akm-help`
     `:embed-content?` - See usage info above
 
-    And see `*config*` docstring for details:
+    And see `*config*` for details:
       `hash-algo`, `sig-algo`, `embed-key-ids?`."
 
   #_(df/reference-data-formats :signed-v1)

--- a/src/taoensso/tempel/keys.clj
+++ b/src/taoensso/tempel/keys.clj
@@ -282,7 +282,7 @@
 
   Return value depends on `:return` option:
     `:keychain` - Returns (possibly new) `KeyChain` (default)
-    `:as-map`   - Returns {:keys [keychain changed? key-id]}"
+    `:map`      - Returns {:keys [keychain changed? key-id]}"
 
   [keychain x-key &
    [{:keys [key-id priority return]
@@ -303,16 +303,16 @@
 
     (case return
       :keychain kc2
-      :as-map
+      :map
       (enc/assoc-some
         {:keychain keychain, :changed? (not (identical? kc1 kc2))}
         :key-id @auto-key-id_)
 
       (enc/unexpected-arg! return
-        {:expected #{:keychain :as-map}
+        {:expected #{:keychain :map}
          :context  `keychain-add-symmetric-key}))))
 
-(comment (keychain-add-symmetric-key (keychain) :random {:return :as-map}))
+(comment (keychain-add-symmetric-key (keychain) :random {:return :map}))
 
 (defn ^:public keychain-add-asymmetric-keypair
   "Produces a ?new `KeyChain` that contains the given asymmetric keypair.
@@ -324,7 +324,7 @@
 
   Return value depends on `:return` option:
     `:keychain` - Returns (possibly new) `KeyChain` (default)
-    `:as-map`   - Returns {:keys [keychain changed? key-id]}
+    `:map`      - Returns {:keys [keychain changed? key-id]}
 
     And see `*config*` for details:
       `keypair-creator`."
@@ -370,13 +370,13 @@
 
     (case return
       :keychain kc2
-      :as-map
+      :map
       (enc/assoc-some
         {:keychain keychain, :changed? (not (identical? kc1 kc2))}
         :key-id @auto-key-id_)
 
       (enc/unexpected-arg! return
-        {:expected #{:keychain :as-map}
+        {:expected #{:keychain :map}
          :context  `keychain-add-asymmetric-keypair}))))
 
 (comment (keychain-add-asymmetric-keypair (keychain)
@@ -1068,7 +1068,7 @@
     `:keychain`   - Returns decrypted `KeyChain` (default)
     `:ba-content` - Returns decrypted byte[] content
     `:ba-aad`     - Returns verified unencrypted embedded ?byte[] AAD
-    `:as-map`     - Returns {:keys [keychain ba-aad ba-content]} map
+    `:map`        - Returns {:keys [keychain ba-aad ba-content]} map
 
   See `keychain-encrypt` for details.
   See Tempel Wiki for detailed usage info, common patterns, examples, etc."
@@ -1167,7 +1167,7 @@
                 :keychain   keychain
                 :ba-content ?ba-ucnt
                 :ba-aad     ?ba-aad
-                :as-map
+                :map
                 (enc/assoc-some
                   {:keychain   keychain}
                   :ba-content  ?ba-ucnt
@@ -1180,7 +1180,7 @@
                   :cnt (bytes/?utf8-ba->?str ?ba-ucnt))
 
                 (enc/unexpected-arg! return
-                  {:expected #{:keychain :ba-content :ba-aad :as-map}
+                  {:expected #{:keychain :ba-content :ba-aad :map}
                    :context  `keychain-decrypt})))))))))
 
 (comment

--- a/src/taoensso/tempel/keys.clj
+++ b/src/taoensso/tempel/keys.clj
@@ -326,7 +326,7 @@
     `:keychain` - Returns (possibly new) `KeyChain` (default)
     `:as-map`   - Returns {:keys [keychain changed? key-id]}
 
-    And see `*config*` docstring for details:
+    And see `*config*` for details:
       `keypair-creator`."
 
   {:arglists
@@ -477,7 +477,7 @@
     `:only?`  - When truthy, returns a `KeyChain` with keys ONLY as
                 specified in call options (ignores any keys specified in `*config*`)
 
-    And see `*config*` docstring for details:
+    And see `*config*` for details:
       `symmetric-keys`, `asymmetric-keys`, `keypair-creator`."
 
   {:arglists '([& [{:keys [empty? only? symmetric-keys asymmetric-keys keypair-creator]}]])}
@@ -935,7 +935,7 @@
 
     - Unencrypted:
       - Any public keys in keychain (retrieve with `public-data`)
-      - Optional AAD (see `aad-help` docstring)
+      - Optional AAD (see `aad-help`)
       - Envelope data necessary for decryption (specifies algorithms, etc.)
 
   Output can be safely stored (e.g. in a database).
@@ -947,12 +947,12 @@
     `:password`   - String, byte[], or char[]             as with `encrypt-with-password`
     `:key-sym`    - `KeyChain` (see `keychain`) or byte[] as with `encrypt-with-symmetric-key`
 
-    `:ba-aad`     - See `aad-help` docstring
-    `:ba-akm`     - See `akm-help` docstring
+    `:ba-aad`     - See `aad-help`
+    `:ba-akm`     - See `akm-help`
     `:ba-content` - Optional additional byte[] content that should be encrypted
                     and included in output for retrieval with `keychain-decrypt`.
 
-    And see `*config*` docstring for details:
+    And see `*config*` for details:
       `hash-algo`, `sym-cipher-algo`, `pbkdf-algo`, `pbkdf-nwf`,
       `embed-key-ids?`, `embed-hmac?`, `backup-key`, `backup-opts`."
 
@@ -1070,7 +1070,7 @@
     `:ba-aad`     - Returns verified unencrypted embedded ?byte[] AAD
     `:as-map`     - Returns {:keys [keychain ba-aad ba-content]} map
 
-  See `keychain-encrypt` docstring for details.
+  See `keychain-encrypt` for details.
   See Tempel Wiki for detailed usage info, common patterns, examples, etc."
 
   #_(df/reference-data-formats :encrypted-keychain-v1)

--- a/test/taoensso/tempel_tests.clj
+++ b/test/taoensso/tempel_tests.clj
@@ -84,43 +84,107 @@
 (comment (with-rand-data 32 64 (fn [ba-cnt ?ba-aad] [(is true) (is false) (is true)])))
 
 (deftest _symmetric-cipher-kit
-  (let [sck    (impl/as-symmetric-cipher-kit :aes-gcm-128-v1)
-        ba-key (as-ba 32 "pwd")]
+  (let [aes-gcm-sck (impl/as-symmetric-cipher-kit :aes-gcm-128-v1)
+        ba-aes-key  (as-ba 32 "pwd")
+        chacha-poly-sck    (impl/as-symmetric-cipher-kit :chacha20-poly1305-v1)
+        ba-chacha-poly-key (as-ba 32 "pwd")
+        ;; Chacha2020-Poly1305 JDK implementation doesn't allow initializing the
+        ;; same cipher instance a second time with the same key and IV (reusing
+        ;; the IV/nonce with the same encryption key completely breaks the
+        ;; security properties of the cipher when encrypting).
+        ;;
+        ;; Because of the way tempel implements symmetric ciphers (keeping a
+        ;; single cipher instance per thread, and calling the initialization
+        ;; method each time an encryption or decryption operation is used), we
+        ;; can't do an encryption operation followed by a decryption operation
+        ;; to test the results. Because in that case **we need** to use the same
+        ;; key and IV (otherwise the decryption will always fail).
+        ;;
+        ;; By the way, pretty much the same happens for AES-GCM cipher
+        ;; instances. But in that case, the JDK implementation only enforces the
+        ;; restriction when initializing the cipher for encryption
+        ;; mode. Decryption mode is not affected in the AES-GCM case (while it
+        ;; is in the Chacha20-Poly1305 case).
+        ;;
+        ;; As a work-around, we "reset" the cipher instance with
+        ;; another (random) IV in between operations.
+        reset-chacha-poly-fn (fn []
+                               ;; Reset the cipher instance internal state by
+                               ;; encrypting irrelevant data with a random IV
+                               (impl/sck-encrypt chacha-poly-sck
+                                                 (impl/rand-ba (impl/sck-iv-len chacha-poly-sck))
+                                                 ba-chacha-poly-key
+                                                 ;; totally irrelevant data and aad
+                                                 (byte-array 0) nil))
+        bit-flip-fn (fn [^"[B" ba idx bit-num]
+                      (aset-byte ba idx (bit-flip (aget ba idx) bit-num))
+                      ba)]
 
     [(testing "Basic operation, with AAD"
        [(let [ba-cnt  (as-ba "cnt")
               ba-aad  (impl/rand-ba 128)
-              ba-iv   (impl/rand-ba (impl/sck-iv-len sck))
-              ba-ecnt (impl/sck-encrypt sck ba-iv ba-key ba-cnt ba-aad)]
+              ba-iv   (impl/rand-ba (impl/sck-iv-len aes-gcm-sck))
+              aes-ba-ecnt (impl/sck-encrypt aes-gcm-sck ba-iv ba-aes-key ba-cnt ba-aad)
+              aes-ba-bad-ecnt (bit-flip-fn (aclone aes-ba-ecnt) 0 1)
+              ba-chacha-poly-iv       (impl/rand-ba (impl/sck-iv-len chacha-poly-sck))
+              chacha-poly-ba-ecnt     (impl/sck-encrypt chacha-poly-sck ba-chacha-poly-iv ba-chacha-poly-key ba-cnt ba-aad)
+              chacha-poly-ba-bad-ecnt (bit-flip-fn (aclone chacha-poly-ba-ecnt) 0 1)]
 
-          [(is (->> (impl/sck-decrypt sck ba-iv ba-key            ba-ecnt ba-aad) enc/utf8-ba->str (= "cnt")))
-           (is (->> (impl/sck-decrypt sck ba-iv (as-ba 32 "!pwd") ba-ecnt ba-aad) (throws? javax.crypto.AEADBadTagException)) "Bad key")])
+          [(is (->> (impl/sck-decrypt aes-gcm-sck ba-iv ba-aes-key        aes-ba-ecnt     ba-aad) enc/utf8-ba->str (= "cnt")))
+           (is (->> (impl/sck-decrypt aes-gcm-sck ba-iv (as-ba 32 "!pwd") aes-ba-ecnt     ba-aad) (throws? javax.crypto.AEADBadTagException)) "Bad key")
+           (is (->> (impl/sck-decrypt aes-gcm-sck ba-iv ba-aes-key        aes-ba-bad-ecnt ba-aad) (throws? javax.crypto.AEADBadTagException)) "Bad key")
+           ;; Same key and IV as in previous call (to encrypt the data), so we need to reset the cipher.
+           (reset-chacha-poly-fn)
+           (is (->> (impl/sck-decrypt chacha-poly-sck ba-chacha-poly-iv ba-chacha-poly-key chacha-poly-ba-ecnt ba-aad) enc/utf8-ba->str (= "cnt")))
+           ;; Different key from previous call, so no need to reset the cipher.
+           (is (->> (impl/sck-decrypt chacha-poly-sck ba-chacha-poly-iv (as-ba 32 "!pwd")  chacha-poly-ba-ecnt ba-aad)
+                    (throws? javax.crypto.AEADBadTagException)) "Bad key")
+           ;; Again, different key from previous call, so no need to reset the cipher.
+           (is (->> (impl/sck-decrypt chacha-poly-sck ba-chacha-poly-iv ba-chacha-poly-key chacha-poly-ba-bad-ecnt ba-aad)
+                    (throws? javax.crypto.AEADBadTagException)) "Bad ciphertext")])
 
-        (let [ba-cnt  (as-ba "cnt")
-              ba-iv   (impl/rand-ba (impl/sck-iv-len sck))
-              ba-ecnt (impl/sck-encrypt sck ba-iv ba-key ba-cnt nil)]
+        (let [ba-cnt (as-ba "cnt")
+              ba-aad (impl/rand-ba 128)
+              ba-iv  (impl/rand-ba (impl/sck-iv-len aes-gcm-sck))
+              ba-ecnt-no-aad (impl/sck-encrypt aes-gcm-sck ba-iv ba-aes-key ba-cnt nil)
+              ba-chacha-poly-iv   (impl/rand-ba (impl/sck-iv-len chacha-poly-sck))
+              chacha-poly-ba-ecnt (impl/sck-encrypt chacha-poly-sck ba-chacha-poly-iv ba-chacha-poly-key ba-cnt nil)
+              ba-bad-aad (bit-flip-fn (aclone ba-aad) 0 1)]
 
-          [(is (->> (impl/sck-decrypt sck ba-iv ba-key ba-ecnt nil) enc/utf8-ba->str (= "cnt")) "No AAD")
-           (is (->> (impl/sck-decrypt sck ba-iv ba-key ba-ecnt (impl/rand-ba 128))
-                 (throws? javax.crypto.AEADBadTagException)) "Bad AAD")])
+          [(is (->> (impl/sck-decrypt aes-gcm-sck ba-iv ba-aes-key ba-ecnt-no-aad nil) enc/utf8-ba->str (= "cnt")) "No AAD")
+           (is (->> (impl/sck-decrypt aes-gcm-sck ba-iv ba-aes-key ba-ecnt-no-aad (impl/rand-ba 128))
+                    (throws? javax.crypto.AEADBadTagException)) "Bad AAD")
+           (reset-chacha-poly-fn)
+           (is (->> (impl/sck-decrypt chacha-poly-sck ba-chacha-poly-iv ba-chacha-poly-key chacha-poly-ba-ecnt nil) enc/utf8-ba->str (= "cnt")) "No AAD")
+           (reset-chacha-poly-fn)
+           (is (->> (impl/sck-decrypt chacha-poly-sck ba-chacha-poly-iv ba-chacha-poly-key chacha-poly-ba-ecnt (impl/rand-ba 128))
+                    (throws? javax.crypto.AEADBadTagException)) "Bad AAD")
+           (reset-chacha-poly-fn)
+           (is (->> (impl/sck-decrypt chacha-poly-sck ba-chacha-poly-iv ba-chacha-poly-key chacha-poly-ba-ecnt ba-bad-aad)
+                    (throws? javax.crypto.AEADBadTagException)) "Bad AAD")])
 
         (with-rand-data (mbytes 4) 256
           (fn [ba-cnt ?ba-aad]
-            (let [ba-iv   (impl/rand-ba (impl/sck-iv-len sck))
-                  ba-ecnt (impl/sck-encrypt sck ba-iv ba-key ba-cnt  ?ba-aad)
-                  ba-dcnt (impl/sck-decrypt sck ba-iv ba-key ba-ecnt ?ba-aad)]
+            (let [ba-iv   (impl/rand-ba (impl/sck-iv-len aes-gcm-sck))
+                  ba-ecnt (impl/sck-encrypt aes-gcm-sck ba-iv ba-aes-key ba-cnt  ?ba-aad)
+                  ba-dcnt (impl/sck-decrypt aes-gcm-sck ba-iv ba-aes-key ba-ecnt ?ba-aad)]
+              (is (bytes/ba= ba-cnt ba-dcnt)))
+            (let [ba-iv   (impl/rand-ba (impl/sck-iv-len chacha-poly-sck))
+                  ba-ecnt (impl/sck-encrypt chacha-poly-sck ba-iv ba-chacha-poly-key ba-cnt  ?ba-aad)
+                  _ (reset-chacha-poly-fn)
+                  ba-dcnt (impl/sck-decrypt chacha-poly-sck ba-iv ba-chacha-poly-key ba-ecnt ?ba-aad)]
               (is (bytes/ba= ba-cnt ba-dcnt)))))])
 
      (testing "Bad ba lengths"
        [(is
           (->>
-            (impl/sck-encrypt sck (impl/rand-ba 4) (impl/rand-ba 128) (as-ba "cnt") nil)
+            (impl/sck-encrypt aes-gcm-sck (impl/rand-ba 4) (impl/rand-ba 128) (as-ba "cnt") nil)
             (throws? :ex-info {:length {:target 12, :actual 4}}))
           "ba-iv too short")
 
         (is
           (->>
-            (impl/sck-encrypt sck (impl/rand-ba 128) (impl/rand-ba 4) (as-ba "cnt") nil)
+            (impl/sck-encrypt aes-gcm-sck (impl/rand-ba 128) (impl/rand-ba 4) (as-ba "cnt") nil)
             (throws? :ex-info {:length {:target 16, :actual 4}}))
           "ba-key too short")])]))
 

--- a/test/taoensso/tempel_tests.clj
+++ b/test/taoensso/tempel_tests.clj
@@ -462,7 +462,7 @@
               enc-backup-opts   (when enc-backup-akm? {:ba-akm                             ba-enc-backup-akm})
               dec-backup-opts   (when enc-backup-akm? {:ba-akm (case dec-backup-akm* :good ba-enc-backup-akm :bad (impl/rand-ba 32) nil nil)})
               enc-opts {:ba-akm ba-enc-akm :backup-key enc-backup-key :backup-opts enc-backup-opts :ba-aad ba-enc-aad :embed-hmac? embed-hmac?}
-              dec-opts {:ba-akm ba-dec-akm :backup-key dec-backup-key :backup-opts dec-backup-opts :return :as-map}
+              dec-opts {:ba-akm ba-dec-akm :backup-key dec-backup-key :backup-opts dec-backup-opts :return :map}
 
               enc-result (try (enc-fn input      enc-key enc-opts) (catch Throwable t {:error t}))
               dec-result (try (dec-fn enc-result dec-key dec-opts) (catch Throwable t {:error t}))
@@ -721,7 +721,7 @@
         (with-rand-data (mbytes 4) 256
           (fn [ba-cnt ?ba-aad]
             (let [ba-signed (sig ba-cnt    kc1 {:ba-aad ?ba-aad})
-                  verified  (ver ba-signed kc1 {:return :as-map})]
+                  verified  (ver ba-signed kc1 {:return :map})]
 
               [(is (bytes/?ba=  ba-cnt (:ba-content verified)))
                (is (bytes/?ba= ?ba-aad (:ba-aad     verified)))])))]))])

--- a/test/taoensso/tempel_tests.clj
+++ b/test/taoensso/tempel_tests.clj
@@ -20,7 +20,7 @@
 (deftest _headers
   [(is (=   (bytes/with-in [in] (bytes/with-out [out] 4 (df/write-head out) (.write out 1)) (df/read-head! in) (.readByte in)) 1))
    (is (->> (bytes/with-in [in] (bytes/with-out [out] 4 (.write out 1))  (df/read-head! in))
-         (enc/throws? :ex-info {:read {:expected [84 80 76]}})))])
+         (throws? :ex-info {:read {:expected [84 80 76]}})))])
 
 (deftest _randomness
   (let [k1 (impl/with-srng-insecure-deterministic!!! 10 (:key-prv (impl/keypair-create* :rsa-2048)))
@@ -47,9 +47,9 @@
          (vec (impl/hmac :sha-256 (as-ba "secret")     (as-ba "c1")     (as-ba "c2")))
          (vec (impl/hmac :sha-256 (as-ba "secret") nil (as-ba "c1") nil (as-ba "c2")))))
 
-   (is (enc/throws? (impl/hmac :sha-256 (byte-array 0)   (as-ba "c1"))))
-   (is (enc/throws? (impl/hmac :sha-256 (as-ba "secret") (byte-array 0))))
-   (is (enc/throws? (impl/hmac :sha-256 (as-ba "secret") (byte-array 0) (byte-array 0))))
+   (is (throws? (impl/hmac :sha-256 (byte-array 0)   (as-ba "c1"))))
+   (is (throws? (impl/hmac :sha-256 (as-ba "secret") (byte-array 0))))
+   (is (throws? (impl/hmac :sha-256 (as-ba "secret") (byte-array 0) (byte-array 0))))
    (is (enc/bytes?  (impl/hmac :sha-256 (as-ba "secret") (byte-array 0) (as-ba "c1"))))])
 
 (deftest _pbkdf-pbkdf2

--- a/wiki/1-Getting-started.md
+++ b/wiki/1-Getting-started.md
@@ -8,14 +8,20 @@ Please be **very careful** evaluating Tempel and/or other cryptographic librarie
 
 # Setup
 
-Add the [relevant dependency](../#latest-releases) to your project:
+Add the [relevant Tempel dependency](../#latest-releases) to your project:
 
 ```clojure
 Leiningen: [com.taoensso/tempel               "x-y-z"] ; or
 deps.edn:   com.taoensso/tempel {:mvn/version "x-y-z"}
 ```
 
-Since Tempel operates primarily on **byte arrays**, you may also want to use something like [Nippy](https://github.com/taoensso/nippy) to help convert your Clojure data types to/from these byte arrays.
+Since Tempel operates primarily on **byte arrays**, you may also want to use something like [Nippy](https://github.com/taoensso/nippy) to help convert your Clojure data types to/from these byte arrays:
+
+```clojure
+;;; Optional
+Leiningen: [com.taoensso/nippy               "x-y-z"] ; or
+deps.edn:   com.taoensso/nippy {:mvn/version "x-y-z"}
+```
 
 Setup your namespace imports:
 
@@ -23,9 +29,24 @@ Setup your namespace imports:
 (ns my-app
   (:require
     [taoensso.tempel :as tempel]
-    [taoensso.nippy  :as nippy] ; Useful, but optional
+    [taoensso.nippy  :as nippy] ; Optional, but useful
     ))
 ```
+
+You may also want to add a dependency for [`com.lambdaworks/scrypt`](https://github.com/wg/scrypt):
+
+```clojure
+;;; Optional
+Leiningen: [com.lambdaworks/scrypt               "1.4.0"] ; or
+deps.edn:   com.lambdaworks/scrypt {:mvn/version "1.4.0"}
+```
+
+This is a Java implementation of [⧉ scrypt](https://en.wikipedia.org/wiki/Scrypt), a particularly secure [⧉ key derivation function](https://en.wikipedia.org/wiki/Key_derivation_function). By default, Tempel will use the following when generating keys from passwords:
+
+- [⧉ scrypt](https://en.wikipedia.org/wiki/Scrypt) when it is present, or
+- [⧉ pbkdf2](https://en.wikipedia.org/wiki/PBKDF2) otherwise
+
+This isn't too important to understand in detail. My recommendation is just to include the above scrypt dependency unless you have a specific reason not to.
 
 # Usage
 

--- a/wiki/2-Examples.md
+++ b/wiki/2-Examples.md
@@ -313,6 +313,8 @@ Using [`encrypt-with-1-keypair`](https://taoensso.github.io/tempel/taoensso.temp
 
 Example use case: allow 2 users to participate in a private conversation viewable only by them. No need for both users to be online simultaneously.
 
+This is an example of [⧉ end-to-end](https://en.wikipedia.org/wiki/End-to-end_encryption) (E2EE) encryption.
+
 Using [`encrypt-with-2-keypairs`](https://taoensso.github.io/tempel/taoensso.tempel.html#var-encrypt-with-2-keypairs) and [`decrypt-with-2-keypairs`](https://taoensso.github.io/tempel/taoensso.tempel.html#var-encrypt-with-2-keypairs):
 
 ```clojure

--- a/wiki/3-FAQ.md
+++ b/wiki/3-FAQ.md
@@ -1,10 +1,10 @@
 # Can I decrypt Tempel data with other tools?
 
-**No**, Tempel is **explicitly not designed** for interop with other general-purpose cryptographic tools or portability between platforms/languages/etc.
+**No**, Tempel is **intentionally not designed** for interop with other general-purpose cryptographic tools or portability between platforms/languages/etc.
 
 Tempel presumes that you'll do both encryption and decryption *using Tempel*, with **Clojure on the JVM**.
 
-This limitation allows Tempel's API and codebase to be kept small and simple.
+This limitation allows Tempel to implement unique features and keep its API and codebase small and simple.
 
 # How secure is Tempel?
 
@@ -59,6 +59,8 @@ To get a realistic idea of performance, I'd recommend **benchmarking in your own
 
 The JVM offers flexible and well-implemented crypto facilities, but they tend to be low-level in nature and are often **difficult to use correctly in practice**.
 
+The same can be said for even excellent libraries like [Bouncing Castle](https://www.bouncycastle.org/).
+
 Understanding what (not) to use and how to compose primitives into a coherent whole can require significant domain experience and/or research. **Mistakes can be costly** - difficult to correct, and potentially insecure.
 
 Tempel uses the JVM's crypto API, but wraps it to:
@@ -73,3 +75,29 @@ Tempel uses the JVM's crypto API, but wraps it to:
 Tempel does not implement ("roll") its own cryptographic primitives, though it *does* necessarily implement its own higher-level protocols and data formats.
 
 See [here](#how-secure-is-tempel) for more info about Tempel's security risks.
+
+# How does Tempel compare to Buddy?
+
+**tl;dr**: Tempel may be a possible alternative for some (but not all) parts of [Buddy](https://github.com/funcool/buddy). There's functionality overlap, but Buddy offers some facilities that Tempel does not and vice versa.
+
+#### Tempel's limitations
+
+- No public API for *low-level cryptographic functionality* as in [buddy-core](https://github.com/funcool/buddy-core), [buddy-hashers](https://github.com/funcool/buddy-hashers), etc.
+- No *authorization* functionality as in [buddy-auth](https://github.com/funcool/buddy-auth)
+- [No support](#can-i-decrypt-tempel-data-with-other-tools) for interop with other tools
+
+#### Tempel's strengths
+
+- A small, particularly easy-to-use high-level [API](./1-Getting-started#what-next) focused on [user keychains](./1-Getting-started#keychains) and keychain management.
+- Data formats designed to easily support item-specific algorithms and parameters, and to support (auto)-updating these kinds of things over time.
+
+#### Tempel's objectives
+
+I've built a number of applications over the years that deal with encrypted user data. Tempel's focused on addressing the *real-world nuisances* that I've personally encountered most often.
+
+These include things like:
+
+- Long-term *key management*.
+- Long-term *maintenance of algorithms and parameters* (scaling work factors and/or adjusting algorithms to keep up with best practice and moving hardware targets over time).
+- A consistent and easy-to-use API for *encrypting data with backup keys* so that it's always possible to reset a user's password, even when the user's data is fully encrypted at rest and the user's key is never stored.
+- A consistent and easy-to-use API for [AAD](https://taoensso.github.io/tempel/taoensso.tempel.html#var-aad-help), [AKM](https://taoensso.github.io/tempel/taoensso.tempel.html#var-akm-help), and [extracting public data](https://taoensso.github.io/tempel/taoensso.tempel.html#var-public-data) from encrypted payloads.


### PR DESCRIPTION
Support for ChaCha20-Poly1305 was added in JDK 11 in 2018 (https://openjdk.org/jeps/329). It is a very popular alternative to AES-GCM, due to its performance [1], and the fact that its used in a lot of security network protocols and tools[2].

[1] Faster than AEC-GCM without hardware AES acceleration, and similar
    or better performace in multi-core machines even with AES hardware
    acceleration; see https://en.wikipedia.org/wiki/ChaCha20-Poly1305#Performance

[2] IPSec, TLS 1.2, DTLS 1.2, TLS 1.3, Wireguard, OTRv4 and multipe
    other protocols (according to https://en.wikipedia.org/wiki/ChaCha20-Poly1305#Use)

[Re: #1]